### PR TITLE
Fixes missing const keyword

### DIFF
--- a/src/logical-tree-builder.js
+++ b/src/logical-tree-builder.js
@@ -76,7 +76,7 @@ function build(queryString) {
 
     // as OR is lower level operator and the last to evaluate, we break-up the term by the 'OR's first
     if (simplified.includes(` ${OR} `)) {
-        orOperands = simplified.split(` ${OR} `).map(elem => elem.trim());
+        const orOperands = simplified.split(` ${OR} `).map(elem => elem.trim());
 
         return {
             OR: orOperands.map((orOperand) => checkForAndOperands(orOperand, subExpressions))


### PR DESCRIPTION
I'm not sure why the test wouldn't detect that. I at least got an error when importing via `https://cdn.skypack.dev/intuitive-json-query-language` (and seeing the code it should be an error).